### PR TITLE
Re-add initial support for control variables

### DIFF
--- a/R/RSA.R
+++ b/R/RSA.R
@@ -82,7 +82,7 @@ RSA <- function(formula, data=NULL, center=FALSE, scale=FALSE, na.rm=FALSE,
 	se = "robust", missing=NA, ..., control.variables=c()) {
 
 
-	if (length(control.variables) > 0) stop("Control.variables feature not implemented yet!")
+	if (length(control.variables) > 0) warning("Some RSA functions do not support control variables.")
 
 	validmodels <- c("absdiff", "absunc", "diff", "mean", "additive", "IA", "SQD", "SRRR", "SRR", "RR", "SSQD", "SRSQD", "full", "null", "onlyx", "onlyy", "onlyx2", "onlyy2", "weak", "strong")
 	
@@ -772,6 +772,7 @@ withCallingHandlers({
 		SRSQD.rot = SRSQD.rot, SRRR.rot = SRRR.rot, LM=summary(lm.full), formula=formula, 
 		data=df, out.rm = out.rm, outliers = which(df$out == TRUE), DV=DV, IV1=IV1, IV2=IV2, IV12=IV12, IV22=IV22, 
 		IV_IA=IV_IA, W_IV1=W_IV1, W_IV2=W_IV2, IV13=IV13, IV23=IV23, IV_IA2=IV_IA2, IV_IA3=IV_IA3, 
+		CV=control.variables,
 		r.squared = summary(lm.full)$r.squared)
 	
 	attr(res, "class") <- "RSA"

--- a/R/getPar.R
+++ b/R/getPar.R
@@ -45,6 +45,11 @@ getPar <- function(x, type="coef", model="full", digits=NA, ...) {
 	if (type=="coef") {
 		p1 <- parameterEstimates(x$models[[model]], ...)
 		p1$label[p1$lhs==x$DV & p1$op=="~1"] <- "b0"
+
+		if (length(x$CV) > 0) {
+		    p1$label[p1$lhs==x$DV & p1$rhs %in% x$CV] <- paste0("bc", 1:length(x$CV))
+		}
+
 		p1 <- data.frame(p1[p1$label != "", ])
 		
 		rownames(p1) <- paste0(p1$lhs, p1$op, p1$rhs)

--- a/R/plot.RSA.R
+++ b/R/plot.RSA.R
@@ -1015,7 +1015,12 @@ plot.RSA <- function(x, ...) {
 	# Adjust the default z-axis if control variables are present, as the surface may not be visible
 	if (is.null(extras$zlim) && length(fit$CV)) {
 	    control.coefs <- C[paste0(fit$DV, '~', fit$CV)]
-	    dv.corrected <- data.used[, fit$DV] - rowSums(mapply(`*`, data.used[, fit$CV], control.coefs))
+	    correction <- mapply(`*`, data.used[, fit$CV], control.coefs)
+	    if (length(fit$CV) > 1) {
+	        correction <- rowSums(correction)
+	    }
+	    
+	    dv.corrected <- data.used[, fit$DV] - correction
 
 	    if (extras$points$show == TRUE) {
 	        extras$zlim <- c(min(data.used[, fit$DV], dv.corrected, na.rm=TRUE), max(data.used[, fit$DV], dv.corrected, na.rm=TRUE))

--- a/R/print.RSA.R
+++ b/R/print.RSA.R
@@ -62,7 +62,11 @@ summary.RSA <- function(object, ..., model="full", digits=3) {
 	} else {
 		coef.sel <- paste0("b", c(0:5, 9:12))
 	}
-	
+
+	if (length(CV) > 0) {
+	    coef.sel <- c(coef.sel, paste0("bc", 1:length(CV)))
+	}
+
 	RC <- eff[eff$label %in% coef.sel, c(1:3, 6:7)]
 	RC[, 2:5] <- round(RC[, 2:5], digits)
 	RC$beta <- round(eff[eff$label %in% coef.sel, "std.all"], digits)

--- a/man/plotRSA.Rd
+++ b/man/plotRSA.Rd
@@ -11,14 +11,15 @@ plotRSA(x = 0, y = 0, x2 = 0, y2 = 0, xy = 0, w = 0, wx = 0,
   lambda = NULL, suppress.surface = FALSE, suppress.box = FALSE,
   rotation = list(x = -63, y = 32, z = 15), label.rotation = list(x = 19, y
   = -40, z = 92), gridsize = 21, bw = FALSE, legend = TRUE,
-  param = TRUE, coefs = FALSE, axes = c("LOC", "LOIC", "PA1", "PA2"),
-  project = c("contour"), maxlines = FALSE, cex = 1, cex.main = 1,
-  points = list(data = NULL, show = NA, value = "raw", jitter = 0, color =
-  "black", cex = 0.5, out.mark = FALSE), fit = NULL, link = "identity",
-  tck = c(1.5, 1.5, 1.5), distance = c(1.3, 1.3, 1.4), border = FALSE,
-  contour = list(show = FALSE, color = "grey40", highlight = c()),
-  hull = NA, showSP = FALSE, showSP.CI = FALSE, pal = NULL,
-  pal.range = "box", pad = 0, demo = FALSE, ...)
+  param = TRUE, coefs = FALSE, control.variables = FALSE,
+  axes = c("LOC", "LOIC", "PA1", "PA2"), project = c("contour"),
+  maxlines = FALSE, cex = 1, cex.main = 1, points = list(data = NULL,
+  show = NA, value = "raw", jitter = 0, color = "black", cex = 0.5, out.mark =
+  FALSE), fit = NULL, link = "identity", tck = c(1.5, 1.5, 1.5),
+  distance = c(1.3, 1.3, 1.4), border = FALSE, contour = list(show =
+  FALSE, color = "grey40", highlight = c()), hull = NA, showSP = FALSE,
+  showSP.CI = FALSE, pal = NULL, pal.range = "box", pad = 0,
+  demo = FALSE, ...)
 }
 \arguments{
 \item{x}{Either an RSA object (returned by the \code{RSA} function), or the coefficient for the X predictor}
@@ -86,6 +87,8 @@ plotRSA(x = 0, y = 0, x2 = 0, y2 = 0, xy = 0, w = 0, wx = 0,
 \item{param}{Should the surface parameters a1 to a4 be shown on the plot? In case of a 3d plot a1 to a4 are printed on top of the plot; in case of a contour plot the principal axes are plotted.}
 
 \item{coefs}{Should the regression coefficients b1 to b5 be shown on the plot? (Only for 3d plot)}
+
+\item{control.variables}{Should the control variables be shown on the plot? (Only for 3d plot)}
 
 \item{axes}{A vector of strings specifying the axes that should be plotted. Can be any combination of c("LOC", "LOIC", "PA1", "PA2"). LOC = line of congruence, LOIC = line of incongruence, PA1 = first principal axis, PA2 = second principal axis}
 


### PR DESCRIPTION
This pull removes the stop again to enable some basic functionality with control variables.
- Added control variables to the RSA object
- Regression coefficients of the control variables are returned from the `getPar` method (with labels `bc1`, `bc2`, ...)
- Regression coefficients of the control variables are printed in the `summary`
- Added `control.variables` flag to the plot method to print the used control variables (default `false`)
- Most importantly: The `plot.RSA` method will recalculate the dependent variable for the plot if the `zlim` argument is not set, to correct for the influence of the control variables. This ensures the correct calculation of the z-axis limits (otherwise the surface may not be visible).
