### PR TITLE
Dynamic length for surface parameter vectors

### DIFF
--- a/R/RSA.ST.R
+++ b/R/RSA.ST.R
@@ -202,7 +202,7 @@ RSA.ST <- function(x=0, y=0, x2=0, xy=0, y2=0, b0=0, SE=NULL, COV=NULL, df=NULL,
 			SP <- data.frame(estimate=c(a1, a2, a3, a4, a5), t.value=rep(NA, 5), p.value=rep(NA, 5))
 		}
 	
-	rownames(SP) <- paste0("a", 1:5)
+	rownames(SP) <- paste0("a", 1:(length(rownames(SP))))
 	
 	PA <- data.frame(estimate=c(as1X, as2X, as3X, as4X, as1Y, as2Y, as3Y, as4Y), SE=NA, t.value=NA, p.value=NA)
 	rownames(PA) <- c(paste0("as", 1:4, "X"), paste0("as", 1:4, "Y"))

--- a/R/confint.R
+++ b/R/confint.R
@@ -51,6 +51,7 @@ confint.RSA <- function(object, parm, level = 0.95, ..., model = "full", digits=
 	
 	if (method == "standard") {
 		p1 <- data.frame(parameterEstimates(object$models[[model]], level=level))
+		p1[which(p1["op"] == "~1" & p1["lhs"] == "z"),"label"] <- "b0"
 		p1 <- p1[p1$label != "", ]
 		rownames(p1) <- p1$label
 		p1 <- p1[, c("ci.lower", "ci.upper", "pvalue")]

--- a/R/plot.RSA.R
+++ b/R/plot.RSA.R
@@ -323,7 +323,7 @@ plotRSA <- function(x=0, y=0, x2=0, y2=0, xy=0, w=0, wx=0, wy=0, x3=0, xy2=0, x2
 			SP <- RSA.ST(fit, model=model)
 			PAR <- getPar(fit, "coef", model=model)
 			
-			SP.text <- paste0("a", 1:5, ": ", f2(SP$SP$estimate, 2), p2star(SP$SP$p.value), collapse="   ")
+			SP.text <- paste0("a", 1:length(SP[["SP"]][["estimate"]], ": ", f2(SP$SP$estimate, 2), p2star(SP$SP$p.value), collapse="   ")
 			
 			a4rs_par <- PAR[PAR$label == "a4.rescaled", ]
 			if (nrow(a4rs_par) == 1) {

--- a/R/plot.RSA.R
+++ b/R/plot.RSA.R
@@ -323,7 +323,7 @@ plotRSA <- function(x=0, y=0, x2=0, y2=0, xy=0, w=0, wx=0, wy=0, x3=0, xy2=0, x2
 			SP <- RSA.ST(fit, model=model)
 			PAR <- getPar(fit, "coef", model=model)
 			
-			SP.text <- paste0("a", 1:length(SP[["SP"]][["estimate"]], ": ", f2(SP$SP$estimate, 2), p2star(SP$SP$p.value), collapse="   ")
+			SP.text <- paste0("a", 1:length(SP[["SP"]][["estimate"]]), ": ", f2(SP$SP$estimate, 2), p2star(SP$SP$p.value), collapse="   ")
 			
 			a4rs_par <- PAR[PAR$label == "a4.rescaled", ]
 			if (nrow(a4rs_par) == 1) {

--- a/R/plot.RSA.R
+++ b/R/plot.RSA.R
@@ -323,7 +323,7 @@ plotRSA <- function(x=0, y=0, x2=0, y2=0, xy=0, w=0, wx=0, wy=0, x3=0, xy2=0, x2
 			SP <- RSA.ST(fit, model=model)
 			PAR <- getPar(fit, "coef", model=model)
 			
-			SP.text <- paste0("a", 1:length(SP[["SP"]][["estimate"]]), ": ", f2(SP$SP$estimate, 2), p2star(SP$SP$p.value), collapse="   ")
+			SP.text <- paste0("a", 1:length(SP$SP$estimate), ": ", f2(SP$SP$estimate, 2), p2star(SP$SP$p.value), collapse="   ")
 			
 			a4rs_par <- PAR[PAR$label == "a4.rescaled", ]
 			if (nrow(a4rs_par) == 1) {


### PR DESCRIPTION
Parameter a5 was not present in the full parameter list for the "diff" model. This was returning an error when assigning row names to surface parameters in the RSA.ST function and adding the surface parameter text in the plot function. Fixed in each by making list of surface parameter row names dynamic. This was a hot fix for me, there may be a more appropriate way to address this.